### PR TITLE
Making logError() and logWarn() support JSON format.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <groupId>com.ft.membership</groupId>
     <artifactId>fluent-logging</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.1</version>
 
     <distributionManagement>
         <snapshotRepository>

--- a/src/main/java/com/ft/membership/logging/LogFormatter.java
+++ b/src/main/java/com/ft/membership/logging/LogFormatter.java
@@ -119,7 +119,7 @@ public class LogFormatter {
             addOperation(operation, msgParams);
             addYield(yield, msgParams);
 
-            logger.warn(buildMsgString(msgParams));
+            logger.warn(buildMsg(operation, msgParams, WARN));
         }
     }
 
@@ -150,7 +150,7 @@ public class LogFormatter {
             addOperation(operation, msgParams);
             addYield(yield, msgParams);
 
-            logger.error(buildMsgString(msgParams));
+            logger.error(buildMsg(operation, msgParams, ERROR));
         }
     }
 


### PR DESCRIPTION
When fluent-logging is used like this:

```
  final Operation operationJson = Operation.operation("isMainImagePresent")
                .jsonLayout().initiate(this);

                operationJson.logIntermediate()
                        .yielding("systemcode", "content-public-read")
                        .yielding("msg", "main image uuid=" + imageId + " was removed because it was not found")
                        .yielding("uuid", imageId)
                        .logWarn();        
```

or this

```
                operationJson.logIntermediate()
                        .yielding("systemcode", "content-public-read")
                        .yielding("msg", "while validating main image uuid=" + imageId + " " + msg)
                        .yielding("uuid", imageId)
                        .logError();

```

it does not log in JSON format.

This is a PR to fix this.