### PR TITLE
Fix/uppsf 743 log json oneline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <groupId>com.ft.membership</groupId>
     <artifactId>fluent-logging</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
 
     <properties>
         <target-jdk>1.8</target-jdk>

--- a/src/main/java/com/ft/membership/logging/LogFormatter.java
+++ b/src/main/java/com/ft/membership/logging/LogFormatter.java
@@ -31,7 +31,7 @@ public class LogFormatter {
     private final ObjectWriter objectWriter;
 
     LogFormatter(Object actorOrLogger) {
-        objectWriter = new ObjectMapper().writerWithDefaultPrettyPrinter();
+        objectWriter = new ObjectMapper().writer();
         checkNotNull(actorOrLogger,"require actor or logger");
         if (actorOrLogger instanceof Logger) {
             logger = (Logger) actorOrLogger;


### PR DESCRIPTION
Make fluent-logging log JSON in one line, otherwise Splunk cannot parse it.