### PR TITLE
Fix Nullpointer from toStringWrapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <groupId>com.ft.membership</groupId>
     <artifactId>fluent-logging</artifactId>
-    <version>4.0.2</version>
+    <version>4.0.3</version>
 
     <properties>
         <target-jdk>1.8</target-jdk>

--- a/src/main/java/com/ft/membership/logging/ToStringWrapper.java
+++ b/src/main/java/com/ft/membership/logging/ToStringWrapper.java
@@ -15,7 +15,7 @@ public class ToStringWrapper {
 
   @Override
   public String toString() {
-    if (value == null) return "null";
+    if (value == null || value.toString() == null) return "null";
     return "\"" + value.toString().replace("\"", "\\\"") + "\"";
   }
 


### PR DESCRIPTION
when ToStringWrapper.toString() is called with value.toString()=null it throws Nullpointer because it calls replace() on null.